### PR TITLE
Key release error fixed

### DIFF
--- a/merlin32/kexec/file.s
+++ b/merlin32/kexec/file.s
@@ -68,7 +68,7 @@ fopen
 		cmp #kernel_event_file_OPENED
 		beq :success
 		cmp #kernel_event_file_ERROR
-		bne :error
+		beq :error
 		bra ]loop
 
 :success

--- a/merlin32/pcopy/file.s
+++ b/merlin32/pcopy/file.s
@@ -96,7 +96,7 @@ fcreate_open
 		cmp #kernel_event_file_OPENED
 		beq :success
 		cmp #kernel_event_file_ERROR
-		bne :error
+		beq :error
 		bra ]loop
 
 :success

--- a/merlin32/pexec/file.s
+++ b/merlin32/pexec/file.s
@@ -74,6 +74,15 @@ fcreate_open
         bcs ]loop
 
 		lda event_type
+
+		do DEBUG_FILE
+		pha
+		jsr TermPrintAH
+		lda #'y'
+		jsr TermCOUT
+		pla
+		fin
+
 		cmp #kernel_event_file_CLOSED
 		beq :error
         cmp #kernel_event_file_NOT_FOUND
@@ -81,7 +90,7 @@ fcreate_open
 		cmp #kernel_event_file_OPENED
 		beq :success
 		cmp #kernel_event_file_ERROR
-		bne :error
+		beq :error
 		bra ]loop
 
 :success

--- a/merlin32/pexec/pexec.s
+++ b/merlin32/pexec/pexec.s
@@ -133,12 +133,16 @@ start
 
 :has_argument		
 		; Display the arguments, hopefully there are some
+		lda	#'"'
+		jsr	TermCOUT
 		ldy	#3
 		lda (kernel_args_ext),y
 		tax
 		dey
 		lda (kernel_args_ext),y
 		jsr TermPUTS
+		lda	#'"'
+		jsr	TermCOUT
 		jsr TermCR
 
 ;------------------------------------------------------------------------------


### PR DESCRIPTION
Sometimes a key release event would be interpreted as a file open error. This seemed to happen only right after a power cycle, but is now stable. Also added are double quotes around the file name, which looks neat.