### PR TITLE
Added description string.

### DIFF
--- a/merlin32/pexec/pexec.s
+++ b/merlin32/pexec/pexec.s
@@ -87,9 +87,9 @@ sig		db $f2,$56		; signature
 		db 0			; reserved
 		asc '-' 		; This will require some discussion with Gadget
 		db 0
-		asc '<file>'
+		asc '<file>'	; argument list
 		db 0
-		asc '"pexec", load and execute file.'
+		asc '"pexec", load and execute file.'	; description
 		db 0
 
 start

--- a/merlin32/pexec/pexec.s
+++ b/merlin32/pexec/pexec.s
@@ -81,9 +81,15 @@ sig		db $f2,$56		; signature
 		db 1            ; 1 8k block
 		db 5            ; mount at $a000
 		da start		; start here
-		dw 0			; version
-		dw 0			; kernel
+		db 1			; version
+		db 0			; reserved
+		db 0			; reserved
+		db 0			; reserved
 		asc '-' 		; This will require some discussion with Gadget
+		db 0
+		asc '<file>'
+		db 0
+		asc '"pexec", load and execute file.'
 		db 0
 
 start


### PR DESCRIPTION
DOS now has the ability to list and show information about flash resident programs. The program header has been changed slightly to enable this feature for pexec. If the string is not satisfactory, I am happy to update the PR.